### PR TITLE
Add database password used by Deloitte's HackerIQ Game

### DIFF
--- a/authors.txt
+++ b/authors.txt
@@ -24,3 +24,4 @@ Ryan Stalets <ryan.stalets@gmail.com>
 Jace Regenbrecht <jaceregenbrecht@gmail.com>
 Tabatha DiDomenico <tabathad@gmail.com>
 Jessica Wilson <hecklinhyde@protonmail.com>
+Galen Guyer <galen@galenguyer.com>

--- a/nerdlist.txt
+++ b/nerdlist.txt
@@ -41,6 +41,7 @@ Assparade1
 asswordp
 asyouwish
 AW96B6
+b3@th@cks
 BZ2UH
 CheesePizzaAndALargeSoda
 PanuccisPizza


### PR DESCRIPTION
Found by @deletescape: https://twitter.com/antiproprietary/status/1324006900401426434/photo/3

Also, Ean said to say they sent me from BSides :)